### PR TITLE
Move from Docker Hub to Google Artifact Registry

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,13 +10,12 @@ env:
   NODE_VERSION: 12
 
 jobs:
-
   build-and-test:
     runs-on: ubuntu-latest
 
     services:
       zilliqa:
-        image: unstoppabledomains/zilliqa-dev-node:v0.0.2
+        image: us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest
         ports:
           - 5555:5555
 
@@ -29,12 +28,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Get yarn cache path
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -46,7 +39,8 @@ jobs:
             ${{ steps.yarn-cache.outputs.dir }}
             node_modules
           key:
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-yarn-dev-${{ hashFiles('yarn.lock') }}
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-yarn-dev-${{
+            hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-yarn-dev-${{ hashFiles('yarn.lock') }}
             ${{ runner.os }}-${{ env.NODE_VERSION }}-yarn-dev-

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Get package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+
       - id: auth
         name: Authenticate to GCP
         uses: google-github-actions/auth@v0
@@ -44,3 +48,11 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Create GitHub Release
+        uses: zendesk/action-create-release@v1
+        id: release
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -28,25 +28,19 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
 
+      - name: Configure Docker with Google Artifact Registry
+        id: push_to_registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+
       - name: Build container image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: false
-          tags:
-            - us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:${{
-              github.event.inputs.tag }}
-            - us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest
+          push: true
+          tags: |
+            us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:${{ github.event.inputs.tag }}
+            us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest
           context: ./docker/build
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Push to Google Artifact Registry
-        id: push_to_registry
-        run: |
-          gcloud auth configure-docker us-central1-docker.pkg.dev
-          docker push us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:${{
-              github.event.inputs.tag }}
-          docker push
-          us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -23,10 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Get package version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-
       - id: auth
         name: Authenticate to GCP
         uses: google-github-actions/auth@v0

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "New tag"
-        default: "v0.0.0"
+        description: 'New tag'
+        default: 'v0.0.0'
         required: true
 
 jobs:
@@ -17,19 +17,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - id: auth
+        name: Authenticate to GCP
+        uses: google-github-actions/auth@v0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          workload_identity_provider:
+            ${{ secrets.WORKLOAD_ID_PROVIDER_PRODUCTION }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT_PRODUCTION }}
 
-      - name: Build and push to DockerHub
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: Build container image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
-          tags: unstoppabledomains/zilliqa-dev-node:${{ github.event.inputs.tag }}
+          push: false
+          tags:
+            - us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:${{
+              github.event.inputs.tag }}
+            - us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest
           context: ./docker/build
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Push to Google Artifact Registry
+        id: push_to_registry
+        run: |
+          gcloud auth configure-docker us-central1-docker.pkg.dev
+          docker push us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:${{
+              github.event.inputs.tag }}
+          docker push
+          us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Configure Docker with Google Artifact Registry
         id: push_to_registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       - name: Build container image
         id: docker_build

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -50,11 +50,3 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Create GitHub Release
-        uses: zendesk/action-create-release@v1
-        id: release
-        with:
-          tag_name: ${{ github.event.inputs.tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-zilliqa-dev-node.yml
+++ b/.github/workflows/build-zilliqa-dev-node.yml
@@ -11,8 +11,14 @@ on:
         required: true
 
 jobs:
-  docker-build:
+  build:
+    name: Build and push container image
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,4 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/vim,node,linux,macos,windows,webstorm+all,visualstudiocode
 
 build/
+.dccache

--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ yarn install
 
 ### Testing
 
-Tests run against standalone zilliqa development node. You will need to install [Docker](https://www.docker.com) before.
+Tests run against standalone zilliqa development node. You will need to install
+[Docker](https://www.docker.com) before.
 
-#### Run zilliqa development node.
+#### Run zilliqa development node
 
-> Note: don't forget to perform `docker login` to be able to pull `unstoppabledomains/zilliqa-dev-node` image
+> Note: don't forget to perform `docker login` to be able to pull
+> `unstoppabledomains/zilliqa-dev-node` image
 
 ```shell script
 yarn zilliqa:start
 ```
 
-It's requires keep port `5555` open on local machine. 
-If port already occupied - you may have `zilliqa-dev-node` already run. 
-You can check this via command below. 
+It's requires keep port `5555` open on local machine. If port already occupied -
+you may have `zilliqa-dev-node` already run. You can check this via command
+below.
 
 #### Check node status
 
@@ -40,14 +42,17 @@ You can check this via command below.
 docker ps
 ```
 
-You should see similar output if node was ran. 
-Almost each docker command requires `CONTAINER ID`. Container id generates automatically on each `docker run`:
+You should see similar output if node was ran. Almost each docker command
+requires `CONTAINER ID`. Container id generates automatically on each
+`docker run`:
+
 ```
 CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS              PORTS                    NAMES
-3ab2b677fd8f        unstoppabledomains/zilliqa-dev-node   "/usr/local/bin/isol…"   11 minutes ago      Up 11 minutes       0.0.0.0:5555->5555/tcp   mystifying_wright
+3ab2b677fd8f        us-central1-docker.pkg... "/usr/local/bin/isol…"   11 minutes ago      Up 11 minutes       0.0.0.0:5555->5555/tcp   mystifying_wright
 ```
 
 #### Run test suite
+
 ```
 yarn test
 ```
@@ -58,31 +63,37 @@ yarn test
 yarn zilliqa:stop
 ```
 
-
 #### Get logs from zilliqa development node
+
 ```shell script
 docker logs <CONTAINER ID>
 ```
 
 #### Run node in foreground to get real-time logs on screen
+
 ```shell script
-docker run -p 5555:5555 unstoppabledomains/zilliqa-dev-node
+docker run -p 5555:5555 us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node
 ```
 
 ## Build zilliqa-dev-node
+
 You may need to rebuild docker image for `zilliqa development node`.
+
 ```shell script
 cd docker/build
 docker build . -t zilliqa-dev-node
 ```
+
 And run your brand new docker image:
+
 ```shell script
 docker run -p 5555:5555 zilliqa-dev-node
 ```
 
 ## Push new zilliqa-dev-node image
 
-To build & push a new version of node image use `Build & Push Zilliqa Dev Node` GitHub Action.
+To build & push a new version of node image use `Build & Push Zilliqa Dev Node`
+GitHub Action.
 
 For an introduction to Zilliqa and Scilla and some of the design considerations
 look at the [Zilliqa Reference](./ZILLIQA.md).
@@ -92,17 +103,16 @@ There are 3 ZNS contract variants.
 - Registry – This contract where the ZNS names are stored. Registry mechanics
   are explained in detail in the [Registry Reference](./REGISTRY.md).
 
-- Resolvers – In order to keep the size of the main ZNS contract low, the ZNS resolution is stored in separate contracts called
-  Resolvers. Resolvers mechanics are explained in detail in the
+- Resolvers – In order to keep the size of the main ZNS contract low, the ZNS
+  resolution is stored in separate contracts called Resolvers. Resolvers
+  mechanics are explained in detail in the
   [Resolvers Reference](./RESOLVERS.md).
 
-- Registrars – These contracts manage the registration of new ZNS names. ZNS has 2
-  of them. An auction registrar, which implements open, ascending price,
+- Registrars – These contracts manage the registration of new ZNS names. ZNS has
+  2 of them. An auction registrar, which implements open, ascending price,
   variable length auction. And a simple registrar listing all names for a fixed
   price designed to be put in place after the initial auction period. Registrar
   mechanics are explained in detail in the
   [Registrar Reference](./REGISTRAR.md).
 
 ## License
-
-

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/unstoppabledomains/zns.git"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/lodash": "^4.14.136",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,16 @@
 {
   "name": "zns",
-  "version": "0.0.0",
+  "description": "Zilliqa Naming Service",
+  "author": {
+    "name": "Unstoppable Domains",
+    "email": "support@unstoppabledomains.com"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/unstoppabledomains/zns.git"
+  },
+  "version": "0.2.0",
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/lodash": "^4.14.136",
@@ -20,10 +30,10 @@
     "testEnvironment": "node"
   },
   "scripts": {
-    "zilliqa:start": "docker run -d -p 5555:5555 unstoppabledomains/zilliqa-dev-node:v0.0.2",
-    "zilliqa:stop": "docker kill `docker ps --filter 'ancestor=unstoppabledomains/zilliqa-dev-node:v0.0.2' -q`",
+    "zilliqa:start": "docker run -d -p 5555:5555 us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest",
+    "zilliqa:stop": "docker kill `docker ps --filter 'ancestor=us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest' -q`",
     "build": "tsc -p . && cp -R scilla build",
-    "contracts": "docker run --entrypoint /bin/sh -v \"$(pwd)\":/zns-contracts unstoppabledomains/zilliqa-dev-node:v0.0.2 -c /zns-contracts/docker/scripts/generate-contract-info.sh",
+    "contracts": "docker run --entrypoint /bin/sh -v \"$(pwd)\":/zns-contracts us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest -c /zns-contracts/docker/scripts/generate-contract-info.sh",
     "test": "yarn contracts && yarn test:standalone-node",
     "test:standalone-node": "ZIL_NODE_TYPE=standalone-node jest smart-contract.test.ts",
     "test:testnet": "ZIL_NODE_TYPE=testnet jest smart-contract.test.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "zilliqa:start": "docker run -d -p 5555:5555 us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest",
     "zilliqa:stop": "docker kill `docker ps --filter 'ancestor=us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest' -q`",
-    "build": "tsc -p . && cp -R scilla build",
+    "build": "tsc -p . && cp -R scilla build; docker build --tag us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest docker/build",
     "contracts": "docker run --entrypoint /bin/sh -v \"$(pwd)\":/zns-contracts us-central1-docker.pkg.dev/unstoppable-domains/zilliqa/zilliqa-dev-node:latest -c /zns-contracts/docker/scripts/generate-contract-info.sh",
     "test": "yarn contracts && yarn test:standalone-node",
     "test:standalone-node": "ZIL_NODE_TYPE=standalone-node jest smart-contract.test.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2617,10 +2617,15 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.17.13:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 long@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This update removes references to Docker Hub and Docker login and replaces them with Google Artifact Registry and Google Cloud login. It also fixes the build and test workflow to properly test a fresh build, as it was previously pulling the most recent image pushed.